### PR TITLE
bin: add usage switch

### DIFF
--- a/bin/man-n
+++ b/bin/man-n
@@ -11,6 +11,18 @@ mdastMan="$prefix/mdast-man"
 badges="$prefix/mdast-strip-badges"
 
 #
+# Usage.
+#
+
+usage () {
+  echo 'usage: man-n <package>'
+}
+
+[ ! "$1" ] && usage && exit 1
+[ "$1" = '-h' ] && usage && exit 0
+[ "$1" = '--help' ] && usage && exit 0
+
+#
 # Options.
 #
 


### PR DESCRIPTION
It might be possible to extend it similar to how [`hub`](http://github.com/github/hub) extends `git -h` once we get wrapping down. Figured it'd be nice to have it show some information in the meantime until we get the more finicky features in. Thanks!

Edit: I believe it's standard to return a `1` statuscode on `-h`? Not sure / not sure it matters.
## Changes
- **bin**: add usage flat that's triggered on no args / `-h` flag
