### PR TITLE
Add support for aliassing `man n` to `man-n`

### DIFF
--- a/bin/man-n
+++ b/bin/man-n
@@ -4,6 +4,7 @@
 # Constants.
 #
 
+original=$(which man)
 input=$(mktemp -t "manXXXXX")
 prefix="$(dirname "$0")/$(dirname "$(readlink "$0")")/../node_modules"
 mdast="$prefix/.bin/mdast"
@@ -18,15 +19,48 @@ usage () {
   echo 'usage: man-n <package>'
 }
 
-[ ! "$1" ] && usage && exit 1
-[ "$1" = '-h' ] && usage && exit 0
-[ "$1" = '--help' ] && usage && exit 0
+#
+# If `--linked`, detect if this is a `n` page.
+#
+
+if [ "$1" = "--linked" ]; then
+  if [ "$2" = "n" ]; then
+    if [ "$3" = "" ]; then
+      usage
+      exit
+    fi
+
+    name="$3"
+  else
+    shift
+    $original "$@"
+    exit
+  fi
+else
+  name="$1"
+fi
+
+#
+# Trigger help.
+#
+
+[ ! "$name" ] && usage && exit 1
+[ "$name" = '-h' ] && usage && exit 0
+[ "$name" = '--help' ] && usage && exit 0
+
+#
+# Link.
+#
+
+if [ "$name" = "--link" ]; then
+  echo "alias \"man=man-n --linked\""
+  exit
+fi
 
 #
 # Options.
 #
 
-name="$1"
 description=$(npm view "$name" description)
 version=$(npm view "$name" version)
 section="n"

--- a/readme.md
+++ b/readme.md
@@ -13,5 +13,18 @@ $ npm install -g man-n
 $ man-n <package>
 ```
 
+## Aliasing
+
+Tired of typing that dash? Add the following to your `.bashrc`,
+`.bash_profile`, or `.zshrc`
+
+```sh
+# Link `man-n` to `man n`
+eval $(man-n --link)
+```
+
+...and from now on, you can just type `man n` to access package
+documentation.
+
 ## License
 [MIT](https://tldrlegal.com/license/mit-license)


### PR DESCRIPTION
``` bash
# Link `man-n` to `man n`
eval $(man-n --link)
```

Closes GH-9.
