### PR TITLE
docs: improve robustness of link script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Tired of typing that dash? Add the following to your `.bashrc`,
 
 ```sh
 # Link `man-n` to `man n`
-eval $(man-n --link)
+$ which man-n && eval $(man-n --link)
 ```
 
 ...and from now on, you can just type `man n` to access package


### PR DESCRIPTION
Sometimes a command is not available when switching node versions
which is super annoying. Checking if a command exists provides a
reasonable fallback.
## Changes
- **docs**: improve robustness of link script in readme
