### PR TITLE
Changes hashbang to bash.

### DIFF
--- a/bin/man-n
+++ b/bin/man-n
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Constants.


### PR DESCRIPTION
The current is `/bin/sh`, but the used syntax is not posix shell compliant, e.g.: `$()` is a bash-ism.

It's unlikely to fail, as most systems link /bin/sh to a shell that would support `$()`, but it's better to be save ;)
