### PR TITLE
Refactors all CLI switches into a single switch statement

### DIFF
--- a/bin/man-n
+++ b/bin/man-n
@@ -51,7 +51,7 @@ fi
 case $1 in
   "")         usage; exit 1 ;;
   -h|--help)  usage; exit ;;
-  --link)     echo "alias \"man=man-n --linked\""; exit ;;
+  --link)     echo 'alias "man=man-n --linked"'; exit ;;
   *)          readonly name=$1 ;;
 esac
 

--- a/bin/man-n
+++ b/bin/man-n
@@ -45,22 +45,15 @@ if [ "$1" = "--linked" ]; then shift;
 fi
 
 #
-# Trigger help.
+# CLI flags
 #
 
-readonly name="$1"
-[ ! "$name" ] && usage && exit 1
-[ "$name" = '-h' ] && usage && exit 0
-[ "$name" = '--help' ] && usage && exit 0
-
-#
-# Link.
-#
-
-if [ "$name" = "--link" ]; then
-  echo "alias \"man=man-n --linked\""
-  exit
-fi
+case $1 in
+  "")         usage; exit 1 ;;
+  -h|--help)  usage; exit ;;
+  --link)     echo "alias \"man=man-n --linked\""; exit ;;
+  *)          readonly name=$1 ;;
+esac
 
 #
 # Options.

--- a/bin/man-n
+++ b/bin/man-n
@@ -4,12 +4,12 @@
 # Constants.
 #
 
-original="$(which man)"
-input="$(mktemp -t "manXXXXX")"
-prefix="$(dirname "$0")/$(dirname "$(readlink "$0")")/../node_modules"
-mdast="$prefix/.bin/mdast"
-mdastMan="$prefix/mdast-man"
-badges="$prefix/mdast-strip-badges"
+readonly original="$(which man)"
+readonly input="$(mktemp -t "manXXXXX")"
+readonly prefix="$(dirname "$0")/$(dirname "$(readlink "$0")")/../node_modules"
+readonly mdast="$prefix/.bin/mdast"
+readonly mdastMan="$prefix/mdast-man"
+readonly badges="$prefix/mdast-strip-badges"
 
 #
 # Usage.


### PR DESCRIPTION
- Simplifies all CLI flag logic to a single switch statement.
- Changes final single-assignment variables to readonly fields.
- Single-quotes the echo argument to avoid inner-escaping.

No worries, now I'm done with the barrage of PRs ;)
