### PR TITLE
link: allow direct aliasing

### DIFF
--- a/bin/man-n
+++ b/bin/man-n
@@ -28,8 +28,6 @@ cat << EOF
   Examples:
 
     $ man-n browserify          # show browserify docs
-    $ man-n --link ls           # show ls(1) docs
-    $ man-n --link n browserify # show browserify docs
 EOF
 }
 
@@ -44,7 +42,7 @@ link () {
     "$man_n" "$@"
     exit
   else
-    "$original" "$@"
+    "$original" "$@" 2>/dev/null || "$man_n" "$@"
     exit
   fi
 }

--- a/bin/man-n
+++ b/bin/man-n
@@ -4,6 +4,7 @@
 # Constants.
 #
 
+readonly man_n="$0"
 readonly original="$(which man)"
 readonly input="$(mktemp -t "manXXXXX")"
 readonly prefix="$(dirname "$0")/$(dirname "$(readlink "$0")")/../node_modules"
@@ -22,36 +23,40 @@ cat << EOF
   Options:
 
     -h, --help  output usage information
-    -l, --link  link \`man-n\` to \`man n\`
+    -l, --link  default to man(1)
 
   Examples:
 
-    $ man-n browserify  # show the browserify documentation
-    $ man-n --link      # link \`man-n\` to \`man n\`
-    $ man n browserify  # show the browserify documentation
+    $ man-n browserify          # show browserify docs
+    $ man-n --link ls           # show ls(1) docs
+    $ man-n --link n browserify # show browserify docs
 EOF
 }
 
 #
-# If `--linked`, detect if this is a `n` page.
+# Switch between man(1) and man-n.
 #
 
-if [ "$1" = "--linked" ]; then shift;
-  if [ "$1" = "n" ]; then shift;
+link () {
+  shift
+  if [ "$1" = "n" ]; then
+    shift
+    "$man_n" "$@"
+    exit
   else
     "$original" "$@"
     exit
   fi
-fi
+}
 
 #
-# CLI flags
+# CLI flags.
 #
 
 case $1 in
   "")         usage; exit 1 ;;
   -h|--help)  usage; exit ;;
-  --link)     echo 'alias "man=man-n --linked"'; exit ;;
+  -l|--link)  link "$@" ;;
   *)          readonly name=$1 ;;
 esac
 

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,13 @@ $ man-n -h
   Options:
 
     -h, --help  output usage information
-    -l, --link  link `man-n` to `man n`
+    -l, --link  default to man(1)
 
   Examples:
 
-    $ man-n browserify  # show the browserify documentation
-    $ man-n --link      # link `man-n` to `man n`
-    $ man n browserify  # show the browserify documentation
+    $ man-n browserify          # show browserify docs
+    $ man-n --link ls           # show ls(1) docs
+    $ man-n --link n browserify # show browserify docs
 ```
 
 ## Aliasing
@@ -32,7 +32,7 @@ Tired of typing that dash? Add the following to your `.bashrc`,
 
 ```sh
 # Link `man-n` to `man n`
-$ which man-n > /dev/null && eval $(man-n --link)
+$ alias "man=man-n --link"
 ```
 
 ...and from now on, you can just type `man n` to access package

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,6 @@ $ man-n -h
   Examples:
 
     $ man-n browserify          # show browserify docs
-    $ man-n --link ls           # show ls(1) docs
-    $ man-n --link n browserify # show browserify docs
 ```
 
 ## Aliasing


### PR DESCRIPTION
Further iteration of #20.

This allows for direct aliasing of `man-n --link`, removing the extra overhead of running `eval` every time a new shell is started. It also exposes a familiar interface to new users by using `alias`. It does add some recursion in the code, but I think it's transparent what's going on as long as users are familiar with `shift(1)`.

This also moves all CLI flags to the `case` statement, making the user interface more transparent and eliminating the need for the undocumented `--linked` flag.

The newly introduced `switch` routine can be replaced with something smarter in the future, possibly allowing to check local deps / remove the need to use `n` in commands. This patch introduces a location to start that work.

Thanks!
## Changes
- **link**: `man-n --link` can now directly be aliased
- **link**: add `-l` as shorthand
- **docs**: update alias example in readme
- **help**: update `--link` usage examples
- **link**: fall back to npm search if `man(1)` yields no results
